### PR TITLE
remove reference of window in the code

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -5,11 +5,10 @@ module.exports = qs
 
 function qs (url) {
   assert.equal(typeof url, 'string', 'nanoquery: url should be type string')
-  assert.ok(typeof window !== 'undefined', 'nanoquery: expected window to exist')
 
   var obj = {}
   url.replace(/^.*\?/, '').replace(reg, function (a0, a1, a2, a3) {
-    obj[window.decodeURIComponent(a1)] = window.decodeURIComponent(a3)
+    obj[decodeURIComponent(a1)] = decodeURIComponent(a3)
   })
 
   return obj


### PR DESCRIPTION
[decodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent) function is a part of ECMA-262 Standard (e.g. part of Javascript). So it is also present as a global variable in Node.js and any other Javascript runtime.