### PR TITLE
Add support for arrays in query

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,4 @@
-var arr = /\[\]$/
-var pair = /([^?=&]+)(=([^&]*))?/g
+var reg = /([^?=&]+)(=([^&]*))?/g
 var assert = require('assert')
 
 module.exports = qs
@@ -8,15 +7,13 @@ function qs (url) {
   assert.equal(typeof url, 'string', 'nanoquery: url should be type string')
 
   var obj = {}
-  url.replace(/^.*\?/, '').replace(pair, function (a0, a1, a2, a3) {
+  url.replace(/^.*\?/, '').replace(reg, function (a0, a1, a2, a3) {
     var value = decodeURIComponent(a3)
     var key = decodeURIComponent(a1)
-    if (arr.test(key)) key = key.replace(arr, '')
     if (obj.hasOwnProperty(key)) {
       if (Array.isArray(obj[key])) obj[key].push(value)
       else obj[key] = [obj[key], value]
     } else {
-      if (arr.test(key)) value = [value]
       obj[key] = value
     }
   })

--- a/browser.js
+++ b/browser.js
@@ -1,4 +1,5 @@
-var reg = /([^?=&]+)(=([^&]*))?/g
+var arr = /\[\]$/
+var pair = /([^?=&]+)(=([^&]*))?/g
 var assert = require('assert')
 
 module.exports = qs
@@ -7,8 +8,17 @@ function qs (url) {
   assert.equal(typeof url, 'string', 'nanoquery: url should be type string')
 
   var obj = {}
-  url.replace(/^.*\?/, '').replace(reg, function (a0, a1, a2, a3) {
-    obj[decodeURIComponent(a1)] = decodeURIComponent(a3)
+  url.replace(/^.*\?/, '').replace(pair, function (a0, a1, a2, a3) {
+    var value = decodeURIComponent(a3)
+    var key = decodeURIComponent(a1)
+    if (arr.test(key)) key = key.replace(arr, '')
+    if (obj.hasOwnProperty(key)) {
+      if (Array.isArray(obj[key])) obj[key].push(value)
+      else obj[key] = [obj[key], value]
+    } else {
+      if (arr.test(key)) value = [value]
+      obj[key] = value
+    }
   })
 
   return obj


### PR DESCRIPTION
This fixes an inconsistency in handling of arrays in query parameters. The node `url` module would recognize multiple params with same name or params with `[]` and treat them s arrays whereas the browser implementation would just use the last value.

```
> 'foo=foo&bar=bar'
{ foo: 'foo', bar: 'bar' }
> 'foo=foo&bar=bar&bar=baz'
{ foo: 'foo', bar: [ 'bar', 'baz' ] }
> 'foo=foo&bar[]=bar&bar[]=baz'
{ foo: 'foo', bar: [ 'bar', 'baz' ] }
```